### PR TITLE
Fix Parser panic when runner reports cpu

### DIFF
--- a/bench/parser.go
+++ b/bench/parser.go
@@ -69,7 +69,7 @@ func (p *Parser) readBenchmarkSuite(first string) (*Suite, error) {
 		} else if strings.HasPrefix(line, "pkg:") {
 			split = strings.Split(line, ": ")
 			suite.Pkg = split[1]
-		} else {
+		} else if strings.HasPrefix(line, "Benchmark") {
 			bench, err := p.readBenchmark(line)
 			if err != nil {
 				return nil, err

--- a/bench/parser_test.go
+++ b/bench/parser_test.go
@@ -34,6 +34,7 @@ func TestParser_readBenchmarkSuite(t *testing.T) {
 		{"go test -bench . ./...", fields{`goos: darwin
 goarch: amd64
 pkg: go.bobheadxi.dev/gobenchdata/demo
+cpu: Intel AMD Xeon Phenom
 BenchmarkFib10/Fib()-12	3293298	330 ns/op
 BenchmarkPizzas/Pizzas()-12	25820055	50.0 ns/op	3.00 pizzas
 PASS`,


### PR DESCRIPTION
Some Github runners report, in addition to and after `pkg:` line, also the CPU name on which the benchmarks are run which results in a panic which this proposed PR fixes:

```
panic: cpu: Intel(R) Xeon(R) Platinum 8275CL CPU @ 3.00GHz: could not parse run: strconv.Atoi: parsing "": invalid syntax (line: cpu: Intel(R) Xeon(R) Platinum 8275CL CPU @ 3.00GHz)
```