### PR TITLE
cli: eval prints pretty report instead of json if -json not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ regressions don't happen:
 
 ```sh
 gobenchdata checks generate
-gobenchdata checks eval ${base benchmarks} ${current benchmarks} --checks.pretty
+gobenchdata checks eval ${base benchmarks} ${current benchmarks}
 ```
 
 <details>

--- a/doc.go
+++ b/doc.go
@@ -26,7 +26,7 @@ Visualize the results:
 Compare results:
 
 	gobenchdata checks generate # generates config file to define checks
-	gobenchdata checks eval base-benchmarks.json current-benchmarks.json --checks.pretty
+	gobenchdata checks eval base-benchmarks.json current-benchmarks.json
 
 Learn more in the repository README: https://github.com/bobheadxi/gobenchdata
 */


### PR DESCRIPTION
`gobenchdata checks eval base-benchmarks.json current-benchmarks.json` should now print a pretty report, and optionally write JSON results _instead_ on `--json`.