### PR TITLE
bench: evaluate mem.BytesPerOp, mem.AllocsPerOp as float64

### DIFF
--- a/bench/benchmark.go
+++ b/bench/benchmark.go
@@ -43,7 +43,10 @@ type Suite struct {
 	Benchmarks []Benchmark
 }
 
-// Benchmark is an individual run
+// Benchmark is an individual run. Note that all metrics in here must be represented as
+// a float type, even if Go only emits integer values, so that in checks we can correctly
+// evaluate divisions so that results come out as floats instead of being truncated to
+// integers.
 type Benchmark struct {
 	Name string
 	Runs int
@@ -55,7 +58,7 @@ type Benchmark struct {
 
 // Mem is memory allocation information about a run
 type Mem struct {
-	BytesPerOp  int
-	AllocsPerOp int
+	BytesPerOp  float64
+	AllocsPerOp float64
 	MBPerSec    float64
 }

--- a/bench/parser.go
+++ b/bench/parser.go
@@ -117,9 +117,9 @@ func (p *Parser) readBenchmark(line string) (*Benchmark, error) {
 		case "ns/op":
 			bench.NsPerOp, err = strconv.ParseFloat(value, 64)
 		case "B/op":
-			bench.Mem.BytesPerOp, err = strconv.Atoi(value)
+			bench.Mem.BytesPerOp, err = strconv.ParseFloat(value, 64)
 		case "allocs/op":
-			bench.Mem.AllocsPerOp, err = strconv.Atoi(value)
+			bench.Mem.AllocsPerOp, err = strconv.ParseFloat(value, 64)
 		case "MB/s":
 			bench.Mem.MBPerSec, err = strconv.ParseFloat(value, 64)
 		default:

--- a/checks/evaluate.go
+++ b/checks/evaluate.go
@@ -81,8 +81,10 @@ func (e EnvDiffFunc) execute(base, current *bench.Benchmark) (float64, error) {
 
 // EvaluateOptions declares options for checks evaluation
 type EvaluateOptions struct {
-	Debug       bool
+	// MustFindAll enforces that all checks must exist in both base and current.
 	MustFindAll bool
+	// Debug enables debug output.
+	Debug bool
 }
 
 // Evaluate checks against benchmark runs

--- a/checks/evaluate_test.go
+++ b/checks/evaluate_test.go
@@ -25,19 +25,37 @@ func TestEnvDiffFunc_execute(t *testing.T) {
 		wantErr bool
 	}{
 		{"return base", fields{"base.NsPerOp"}, args{
-			&bench.Benchmark{NsPerOp: 10},
-			&bench.Benchmark{NsPerOp: 20},
+			base:    &bench.Benchmark{NsPerOp: 10},
+			current: &bench.Benchmark{NsPerOp: 20},
 		}, 10, false},
 		{"return current", fields{"current.NsPerOp"}, args{
-			&bench.Benchmark{NsPerOp: 10},
-			&bench.Benchmark{NsPerOp: 20},
+			base:    &bench.Benchmark{NsPerOp: 10},
+			current: &bench.Benchmark{NsPerOp: 20},
 		}, 20, false},
 		{"basic arithmetic", fields{
 			"base.NsPerOp / current.NsPerOp * 100",
 		}, args{
-			&bench.Benchmark{NsPerOp: 10},
-			&bench.Benchmark{NsPerOp: 20},
+			base:    &bench.Benchmark{NsPerOp: 10},
+			current: &bench.Benchmark{NsPerOp: 20},
 		}, 50, false},
+		{"nested field basic arithmetic", fields{
+			"current.Mem.BytesPerOp - base.Mem.BytesPerOp",
+		}, args{
+			base:    &bench.Benchmark{Mem: bench.Mem{BytesPerOp: 10}},
+			current: &bench.Benchmark{Mem: bench.Mem{BytesPerOp: 16}},
+		}, 6, false},
+		{"nested field basic division", fields{
+			"current.Mem.BytesPerOp / base.Mem.BytesPerOp",
+		}, args{
+			base:    &bench.Benchmark{Mem: bench.Mem{BytesPerOp: 10}},
+			current: &bench.Benchmark{Mem: bench.Mem{BytesPerOp: 16}},
+		}, 1.6, false},
+		{"nested field division", fields{
+			"(current.Mem.BytesPerOp - base.Mem.BytesPerOp) / base.Mem.BytesPerOp * 100",
+		}, args{
+			base:    &bench.Benchmark{Mem: bench.Mem{BytesPerOp: 10}},
+			current: &bench.Benchmark{Mem: bench.Mem{BytesPerOp: 16}},
+		}, 60, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/fixtures/sample-benchmarks.json
+++ b/fixtures/sample-benchmarks.json
@@ -1,3 +1,3 @@
 [
-    {"Version":"a3b33d25b34e359f022b5a3dfc3607369143e74d","Date":1589695147,"Tags":["ref=refs/tags/v1.0.0"],"Suites":[{"Goos":"linux","Goarch":"amd64","Pkg":"go.bobheadxi.dev/gobenchdata/demo","Benchmarks":[{"Name":"BenchmarkFib10/Fib()","Runs":2819560,"NsPerOp":419,"Mem":{"BytesPerOp":0,"AllocsPerOp":0,"MBPerSec":0}},{"Name":"BenchmarkFib10/Fib()-2","Runs":2991747,"NsPerOp":412,"Mem":{"BytesPerOp":0,"AllocsPerOp":0,"MBPerSec":0}}]}]}
+    {"Version":"a3b33d25b34e359f022b5a3dfc3607369143e74d","Date":1589695147,"Tags":["ref=refs/tags/v1.0.0"],"Suites":[{"Goos":"linux","Goarch":"amd64","Pkg":"go.bobheadxi.dev/gobenchdata/demo","Benchmarks":[{"Name":"BenchmarkFib10/Fib()","Runs":2819560,"NsPerOp":419,"Mem":{"BytesPerOp":0,"AllocsPerOp":0,"MBPerSec":0}},{"Name":"BenchmarkFib10/Fib()-2","Runs":2991747,"NsPerOp":412,"Mem":{"BytesPerOp":12,"AllocsPerOp":14,"MBPerSec":15}}]}]}
 ]

--- a/io_test.go
+++ b/io_test.go
@@ -8,11 +8,11 @@ import (
 	"go.bobheadxi.dev/gobenchdata/bench"
 )
 
-func Test_showHelp(t *testing.T) {
+func TestShowHelp(t *testing.T) {
 	showHelp()
 }
 
-func Test_load(t *testing.T) {
+func TestLoad(t *testing.T) {
 	type args struct {
 		files []string
 	}
@@ -35,7 +35,7 @@ func Test_load(t *testing.T) {
 						Pkg:    "go.bobheadxi.dev/gobenchdata/demo",
 						Benchmarks: []bench.Benchmark{
 							{Name: "BenchmarkFib10/Fib()", Runs: 2819560, NsPerOp: 419, Mem: bench.Mem{BytesPerOp: 0, AllocsPerOp: 0, MBPerSec: 0}, Custom: nil},
-							{Name: "BenchmarkFib10/Fib()-2", Runs: 2991747, NsPerOp: 412, Mem: bench.Mem{BytesPerOp: 0, AllocsPerOp: 0, MBPerSec: 0}, Custom: nil},
+							{Name: "BenchmarkFib10/Fib()-2", Runs: 2991747, NsPerOp: 412, Mem: bench.Mem{BytesPerOp: 12, AllocsPerOp: 14, MBPerSec: 15}, Custom: nil},
 						},
 					},
 				},


### PR DESCRIPTION
Fixes issue with `BytesPerOp` checks evaluating incorrectly as reported in https://github.com/bobheadxi/gobenchdata/issues/57 by representing `mem.BytesPerOp`, `mem.AllocsPerOp` as float64

Details: This is related to https://github.com/antonmedv/expr/issues/77 , which is caused by how Go handles division: https://stackoverflow.com/questions/32815400/how-to-perform-division-in-go - `int / int = int`, so we get results like `6 / 10 = 0`, which is pretty confusing. To remedy this, we represent fields that are always `int` to be `float64` anyway.

Closes https://github.com/bobheadxi/gobenchdata/issues/57