### PR TITLE
entrypoint.sh: update setting output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,7 +71,7 @@ if [[ "${INPUT_PUBLISH}" == "true" || "${INPUT_CHECKS}" == "true" ]]; then
       --json ${CHECKS_OUTPUT} \
       --flat
     RESULTS=$(cat ${CHECKS_OUTPUT})
-    echo "::set-output name=checks-results::$RESULTS"
+    echo "checks-results=$RESULTS" >> ${GITHUB_OUTPUT}
 
     # output results
     echo


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

<img width="1060" alt="image" src="https://user-images.githubusercontent.com/870638/211521052-74fc9621-b861-45e7-b21c-9152d9936654.png">

☝️ I hope this removes the warning.

⚠️ I have not done thorough testing of this, I'm afraid. But I think there's some CI on the repo...? 🤔 